### PR TITLE
Add support for bulb shooting

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var minVersionRequired = '2.1.4';
           if(error) {
             if(error.length > 0 && error[0] == 1 && method == 'getEvent') {
               setTimeout(function() {
-                self.call(method, params, callback); 
+                self.call(method, params, callback);
               });
               return;
             }
@@ -106,7 +106,7 @@ var minVersionRequired = '2.1.4';
           self.method = 'new';
           self.port = 10000;
           setTimeout(function() {
-            self.call(method, params, callback); 
+            self.call(method, params, callback);
           });
           return;
         }
@@ -167,7 +167,7 @@ var minVersionRequired = '2.1.4';
               console.log("SonyWifi: " + item.type + " = " + self.params[item.type].current + "(+" + (self.params[item.type].available ? self.params[item.type].available.length : "NULL")  + " available)");
               self.emit("update", item.type, self.params[item.type]);
             }
-          } 
+          }
         }
       }
 
@@ -378,6 +378,16 @@ var minVersionRequired = '2.1.4';
     }
 
     self.call('actTakePicture', null, processCaptureResult);
+  };
+
+  SonyCamera.prototype.startBulbShooting = function (callback) {
+    console.log('startBulbShooting');
+    this.call('startBulbShooting', null, callback);
+  };
+
+  SonyCamera.prototype.stopBulbShooting = function (callback) {
+    console.log('stopBulbShooting');
+    this.call('stopBulbShooting', null, callback);
   };
 
   SonyCamera.prototype.zoomIn = function (callback) {


### PR DESCRIPTION
It supports long-exposure shooting above 30 seconds, mainly used for astrophotography(capturing a deep-sky object).

It is fairly simple but undocumented, but found and added it.